### PR TITLE
remove references to adapters in daily ppa

### DIFF
--- a/linux/debian/daily/python-kivy.install
+++ b/linux/debian/daily/python-kivy.install
@@ -1,6 +1,5 @@
 usr/lib/python2.7/dist-packages/Kivy-*.egg-info
 usr/lib/python2.7/dist-packages/kivy/*.*
-usr/lib/python2.7/dist-packages/kivy/adapters
 usr/lib/python2.7/dist-packages/kivy/core
 usr/lib/python2.7/dist-packages/kivy/data
 usr/lib/python2.7/dist-packages/kivy/deps

--- a/linux/debian/daily/python3-kivy.install
+++ b/linux/debian/daily/python3-kivy.install
@@ -1,7 +1,6 @@
 usr/lib/python3/dist-packages/Kivy-*.egg-info
 usr/lib/python3/dist-packages/kivy/*.*
 usr/lib/python3/dist-packages/kivy/__pycache__
-usr/lib/python3/dist-packages/kivy/adapters
 usr/lib/python3/dist-packages/kivy/core
 usr/lib/python3/dist-packages/kivy/data
 usr/lib/python3/dist-packages/kivy/deps


### PR DESCRIPTION
since they got removed along listview in commit
d78d435a383dfd37ce3f1b047c344b2f86ded809 of kivy.