### PR TITLE
try setting sphinx-build to python2 version before doc build

### DIFF
--- a/linux/debian/stable/rules
+++ b/linux/debian/stable/rules
@@ -17,6 +17,7 @@ override_dh_auto_build:
 
 override_dh_installdocs:
 	$(MAKE) build
+	update-alternatives --set sphinx-build /usr/share/sphinx/scripts/python2/sphinx-build
 	cd doc && PYTHONPATH=.. make html
 	dh_installdocs
 	$(MAKE) distclean


### PR DESCRIPTION
not tested, but the update-alternative command worked in docker, hopefully it'll fix the ppa