### PR TITLE
Add kivy/eventmanager

### DIFF
--- a/linux/debian/daily/python3-kivy.install
+++ b/linux/debian/daily/python3-kivy.install
@@ -5,6 +5,7 @@ usr/lib/python3/dist-packages/kivy/core
 usr/lib/python3/dist-packages/kivy/data
 usr/lib/python3/dist-packages/kivy/deps
 usr/lib/python3/dist-packages/kivy/effects
+usr/lib/python3/dist-packages/kivy/eventmanager
 usr/lib/python3/dist-packages/kivy/extras
 usr/lib/python3/dist-packages/kivy/garden
 usr/lib/python3/dist-packages/kivy/graphics

--- a/linux/debian/stable/python3-kivy.install
+++ b/linux/debian/stable/python3-kivy.install
@@ -5,6 +5,7 @@ usr/lib/python3/dist-packages/kivy/core
 usr/lib/python3/dist-packages/kivy/data
 usr/lib/python3/dist-packages/kivy/deps
 usr/lib/python3/dist-packages/kivy/effects
+usr/lib/python3/dist-packages/kivy/eventmanager
 usr/lib/python3/dist-packages/kivy/extras
 usr/lib/python3/dist-packages/kivy/garden
 usr/lib/python3/dist-packages/kivy/graphics


### PR DESCRIPTION
This PR adds `kivy/eventmanager` that have been introduced in  https://github.com/kivy/kivy/pull/7658