### PR TITLE
Windows: SDL2 to 2.24.0, SDL2_mixer to 2.6.2, SDL2_ttf to 2.20.1, SDL_image to 2.6.2

### DIFF
--- a/ci/windows_ci.ps1
+++ b/ci/windows_ci.ps1
@@ -49,7 +49,7 @@ function Test-kivy() {
 
     python -m pip config set install.find-links "$(pwd)\dist"
 
-    git clone --depth 1 git://github.com/kivy/kivy.git kivy_src
+    git clone --depth 1 https://github.com/kivy/kivy.git kivy_src
     # use the current kivy_deps just built, not the older version specified in the reqs
     ((get-content -Path kivy_src/pyproject.toml -Raw) -replace "kivy_deps.$env:PACKAGE_TARGET`_dev~.+;","kivy_deps.$env:PACKAGE_TARGET`_dev;") | set-content -Path kivy_src/pyproject.toml
     ((get-content -Path kivy_src/pyproject.toml -Raw) -replace "kivy_deps.$env:PACKAGE_TARGET~.+;","kivy_deps.$env:PACKAGE_TARGET;") | set-content -Path kivy_src/pyproject.toml

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -1,12 +1,12 @@
 from os import walk
 from .common import *
 
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
-sdl2_ver = '2.0.20'
-sdl2_mixer_ver = '2.0.4'
-sdl2_ttf_ver = '2.0.18'
-sdl2_image_ver = '2.0.5'
+sdl2_ver = '2.24.0'
+sdl2_mixer_ver = '2.6.2'
+sdl2_ttf_ver = '2.20.1'
+sdl2_image_ver = '2.6.2'
 
 
 def get_sdl2(cache, build_path, arch, package, output, download_only=False):

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -1,7 +1,7 @@
 from os import walk
 from .common import *
 
-__version__ = '0.4.6'
+__version__ = '0.5.0'
 
 sdl2_ver = '2.24.0'
 sdl2_mixer_ver = '2.6.2'


### PR DESCRIPTION
**Windows:**
- Bumps SDL2 to `2.24.0` (the same pinned in `kivy/kivy` for macOS and Linux wheels)
- Bumps  SDL2_mixer to `2.6.2`  (the same pinned in `kivy/kivy` for macOS and Linux wheels)
- Bumps  SDL2_ttf to `2.20.1`  (the same pinned in `kivy/kivy` for macOS and Linux wheels)
- Bumps  SDL_image to `2.6.2`  (the same pinned in `kivy/kivy` for macOS and Linux wheels)
- Bumps `kivy_deps.sdl2_dev` and `kivy_deps.sdl2` to `0.4.6`


PS: `git://github.com/kivy/kivy.git` was failing.


⚠️ When merging into `master`, we should add `[publish sdl2 win]` into the commit message.