### PR TITLE
Add support for Python 3.11 and bump dependencies to latest versions

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   prepare_angle:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     steps:
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/win/angle.py
+++ b/win/angle.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from .common import *
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 
 def get_angle(cache, build_path, arch, package, output, download_only=False):

--- a/win/gstreamer.py
+++ b/win/gstreamer.py
@@ -6,9 +6,9 @@ from os import walk, listdir, remove
 from .common import *
 import glob  # also imported in common so it must be after
 
-__version__ = '0.3.4'
+__version__ = '0.4.0'
 
-gst_ver = '1.20.0'
+gst_ver = '1.21.1'
 
 glob_escape = glob.escape
 

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -1,9 +1,9 @@
 from os import walk
 from .common import *
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
-sdl2_ver = '2.24.0'
+sdl2_ver = '2.24.1'
 sdl2_mixer_ver = '2.6.2'
 sdl2_ttf_ver = '2.20.1'
 sdl2_image_ver = '2.6.2'


### PR DESCRIPTION
- `angle`: There's at least a new commit since our last release, so the new artifact will be different. That means we need to also bump the version (from `0.3.2` to `0.3.3`)
- `glew`: No new releases here. Kept the version to `0.3.1` (Upload to pypi will fail for `3.7`,`3.8`,`3.9`,`3.10`)
- `sdl2`: SDL2 `2.24.1` has been released, so there's a chance to upgrade here. Bumped version from `0..5.0` to `0.5.1`
- `gstreamer`: There's a (non-bugfix) release for that package. Bumped version from `0.3.4` to `0.4.0`

Check if builds:
- [x] angle
- [x] glew
- [x] sdl2
- [x] gstreamer

All the dependencies will fail the latest test step on `3.11`. This is expected.

**Reminder**: Add `[publish sdl2 win] [publish gstreamer win] [publish glew win] [publish angle win]` on commit message.