### PR TITLE
Revert to a previous gstreamer version - we can't publish wheels > 150M on PyPi

### DIFF
--- a/ci/windows_ci.ps1
+++ b/ci/windows_ci.ps1
@@ -30,7 +30,7 @@ function Download-Packages() {
 
 
 function Create-Packages() {
-    python -m pip install pip wheel setuptools --upgrade
+    python -m pip install pip wheel<0.38.0 setuptools --upgrade
     python -m "win.$env:PACKAGE_TARGET" build_path "$(pwd)\$env:KIVY_BUILD_DIR" arch $env:PACKAGE_ARCH package $env:PACKAGE_TARGET output "$(pwd)\dist" cache "$(pwd)\$env:KIVY_BUILD_CACHE"
     dir "$(pwd)\dist"
     rm "$(pwd)\dist\*tar.gz"

--- a/win/gstreamer.py
+++ b/win/gstreamer.py
@@ -6,9 +6,9 @@ from os import walk, listdir, remove
 from .common import *
 import glob  # also imported in common so it must be after
 
-__version__ = '0.4.0'
+__version__ = '0.3.3'
 
-gst_ver = '1.21.1'
+gst_ver = '1.18.5'
 
 glob_escape = glob.escape
 


### PR DESCRIPTION
From @matham on https://github.com/kivy/kivy-sdk-packager/pull/82 :
> I'm think with gstreamer we probably don't need to release updates more than once or twice a year, because the files are quite large and the fixes are not really urgent. Last time I asked about this on pypi-support nothing happened.
 I'd suggest to remove the 0.4.0 release from pypi and instead only release the 3.11 wheels for 0.3.3. No one should have used 0.4.0 yet, because kivy is locked to 0.3.x so removing it should be fine.

I've been away from my laptop for more than a week and even delivered some Kivy t-shirts to our fellow in Amsterdam, but unfortunately still no reply from `pypi-support` 😂

Considering that there's an urge to test everything on `3.11` and schedule a new Kivy release:

- Reverted our gstreamer package version to `0.3.3` and set the `gstreamer` version to `1.18.5` (The same currently available on PyPi for 3.7, 3.8, 3.9, 3.10)

- Forced `wheel<0.38.0` as `wheel>=0.38.0` silently freezes the CI. `wheel==0.38.0` has been released on 21 Oct, but later yanked due to an issue with setuptools. `wheel==0.38.1` and `wheel==0.38.1` have been respectively released on 4 Nov and 5 Nov, and both are freezing our CI for hours. Hopefully is something that needs to be fixed on their side, but we'll need to keep track of it.

- About `0.4.0`: Only `-win32` artifacts have been successfully uploaded. We can safely delete that release, but we need to recall that `0.4.0` will not ever be usable anymore. (A comment into the code will be enough)

⚠️ When merging into master, we should add `[publish gstreamer win]` into the commit message.