### PR TITLE
Bump dependencies versions before Kivy 2.2.0

### DIFF
--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -1,12 +1,12 @@
 from os import walk
 from .common import *
 
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
-sdl2_ver = '2.24.1'
-sdl2_mixer_ver = '2.6.2'
-sdl2_ttf_ver = '2.20.1'
-sdl2_image_ver = '2.6.2'
+sdl2_ver = '2.26.4'
+sdl2_mixer_ver = '2.6.3'
+sdl2_ttf_ver = '2.20.2'
+sdl2_image_ver = '2.6.3'
 
 
 def get_sdl2(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
- SDL2 dependencies internal version has been bumped to `0.6.0` (SDL2 changed from `2.24.1` to `2.26.4`)
- Bumped `SDL_image`, `SDL_ttf` and `SDL_mixer` bugfix versions.
- `angle` and `glew` have not been updated, so a new release is not needed.
- `gstreamer` has been updated, but we decided to not update it to avoid polluting PyPI: https://github.com/kivy/kivy-sdk-packager/pull/84

⚠️ When merging into master, we should add `[publish sdl2 win]` into the commit message.

Ref: https://github.com/kivy/kivy/issues/8167