### PR TITLE
Apply patches to avoid usage of `sphinxcontrib.jquery` module.

### DIFF
--- a/linux/debian/daily/rules
+++ b/linux/debian/daily/rules
@@ -23,6 +23,7 @@ override_dh_installdocs:
 	mkdir pypackages;
 	python3 -m pip list;
 	python3 -m pip install $(CURDIR)/cython -t $(CURDIR)/pypackages --no-deps --upgrade || true;
+	patch doc/sources/conf.py < kivy-ppa-patches/disable-sphinxcontrib-jquery.patch;
 	python3 -m pip list;
 	$(MAKE) PYTHON=python3 force;
 	cd doc && PYTHONPATH=..:$PYTHONPATH make html;

--- a/linux/debian/stable/rules
+++ b/linux/debian/stable/rules
@@ -23,6 +23,7 @@ override_dh_installdocs:
 	mkdir pypackages;
 	python3 -m pip list;
 	python3 -m pip install $(CURDIR)/cython -t $(CURDIR)/pypackages --no-deps --upgrade || true;
+	patch doc/sources/conf.py < kivy-ppa-patches/disable-sphinxcontrib-jquery.patch;
 	python3 -m pip list;
 	$(MAKE) PYTHON=python3 force;
 	cd doc && PYTHONPATH=..:$PYTHONPATH make html;


### PR DESCRIPTION
Installing Python packages during PPA builds is a headache, since `pip install this-package` just does not work. (build machines does not have access to public internet).

The only way is to manually build and install packages from sources, which is a pain if the packages have multiple sub-dependencies, since sources need to be made available via a synced repo in launchpad. (again, can't use the public internet).

Since `sphinxcontrib.jquery` is not needed here, instead of getting mad, we just avoid to use the dependency by patching the needed files. (patches are hosted at https://code.launchpad.net/~misl6/kivy/+git/kivy-ppa-patches in `main` and `stable` branches). The patches repo is added via the recipe on Launchpad UI.