### PR TITLE
Update Ubuntu PPA stable to 2.2.1

### DIFF
--- a/linux/debian/stable/changelog
+++ b/linux/debian/stable/changelog
@@ -1,3 +1,9 @@
+kivy (2.2.1-0) stable; urgency=medium
+
+  * update to new release
+
+ -- Mirko Galimberti <me@mirkogalimberti.com>  Sat, 17 Jun 2023 18:25:00 +0200
+
 kivy (2.2.0-0) stable; urgency=medium
 
   * update to new release


### PR DESCRIPTION
- Updates changelog for `stable`, which is now at release 2.2.1