### PR TITLE
[publish sdl2 win] Update `sdl2` and `sdl_image` versions and add Python `3.12` to supported matrix

### DIFF
--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'win/common.py'
       - 'win/sdl2.py'
+      - 'ci/windows_ci.ps1'
       - '.github/workflows/windows_sdl2_wheels.yml'
 
 env:
@@ -26,14 +27,14 @@ jobs:
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Cache deps
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: kivy_build_cache
           key: cache-packages-sdl2-${{ matrix.arch }}-${{ hashFiles('win/sdl2.py') }}
@@ -52,19 +53,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' , '3.12' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
     - name: Cache deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: kivy_build_cache
         key: cache-packages-sdl2-${{ matrix.arch }}-${{ hashFiles('win/sdl2.py') }}
@@ -77,7 +78,7 @@ jobs:
         . .\ci\windows_ci.ps1
         Create-Packages
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: sdl2_wheels
         path: dist

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -6,7 +6,7 @@ __version__ = '0.7.0'
 sdl2_ver = '2.28.5'
 sdl2_mixer_ver = '2.6.3'
 sdl2_ttf_ver = '2.20.2'
-sdl2_image_ver = '2.6.3'
+sdl2_image_ver = '2.7.1'
 
 
 def get_sdl2(cache, build_path, arch, package, output, download_only=False):

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -66,6 +66,11 @@ def get_sdl2(cache, build_path, arch, package, output, download_only=False):
                 if dirpath and dirpath[0] == sep:
                     dirpath = dirpath[1:]
 
+                if dirpath == "optional":
+                    # SDL_* optional libraries should stay in the same
+                    # directory as the main library
+                    dirpath = ""
+
                 for filename in filenames:
                     is_dev = d != 'bin'
                     if d == 'lib':

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -1,9 +1,9 @@
 from os import walk
 from .common import *
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 
-sdl2_ver = '2.26.4'
+sdl2_ver = '2.28.5'
 sdl2_mixer_ver = '2.6.3'
 sdl2_ttf_ver = '2.20.2'
 sdl2_image_ver = '2.6.3'

--- a/win/sdl2.py
+++ b/win/sdl2.py
@@ -6,7 +6,7 @@ __version__ = '0.7.0'
 sdl2_ver = '2.28.5'
 sdl2_mixer_ver = '2.6.3'
 sdl2_ttf_ver = '2.20.2'
-sdl2_image_ver = '2.7.1'
+sdl2_image_ver = '2.8.0'
 
 
 def get_sdl2(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
- ~~We were waiting for an update on `SDL_image`, in order to avoid multiple releases in a short time, but since there's no update, better to move ahead.~~
- Bump `sdl2` from `2.26.4` to `2.28.5`, bump `sdl_image` from `2.6.3` to `2.8.0` (and therefore our internal version moved from `0.6.0` to `0.7.0`
- Added Python `3.12` to supported matrix for `sdl2` deps.
- Updated Github Actions
- Fixes https://github.com/kivy/kivy/issues/8200
