### PR TITLE
Make doc structure consistent and up-to-date

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+In the interest of fostering an open and welcoming community, we as 
+contributors and maintainers need to ensure participation in our project and 
+our sister projects is a harassment-free and positive experience for everyone. 
+It is vital that all interaction is conducted in a manner conveying respect, 
+open-mindedness and gratitude.
+
+Please consult the [latest Kivy Code of Conduct](https://github.com/kivy/kivy/blob/master/CODE_OF_CONDUCT.md).
+

--- a/CONTACT.md
+++ b/CONTACT.md
@@ -1,0 +1,6 @@
+# Contacting the Kivy Team
+
+If you are looking to contact the Kivy Team (who are responsible for managing
+the Kivy SDK Packager project), including looking for support, please see our
+latest [Contact Us](https://github.com/kivy/kivy/blob/master/CONTACT.md) 
+document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contribution Guidelines
+
+Kiby SDK Packaging is part of the [Kivy](https://kivy.org) ecosystem - a large group of
+products used by many thousands of developers for free, but it
+is built entirely by the contributions of volunteers. We welcome (and rely on) 
+users who want to give back to the community by contributing to the project.
+
+Contributions can come in many forms. See the latest 
+[Contribution Guidelines](https://github.com/kivy/kivy/blob/master/CONTRIBUTING.md)
+for how you can help us.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2015-2017 Kivy Team and other contributors
+MIT License
+
+Copyright (c) 2015-2023 Kivy Team and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ specifications (recipes) provided here.
 | Stable Build | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       |
 | Daily Build  | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) |
 
-[Kivy SDK for Linux README](linux/README.md)
+[Kivy SDK for Linux README](linux/debian/README.md)
 
 ## macOS
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,55 @@
-Kivy SDK Packager
+kivy-sdk-packager
 =================
 
-Kivy Software Development Kit (Kivy SDK) is an installable package of all the 
-basic dependencies needed to run [Kivy framework](https://kivy.org) apps.
+`kivy-sdk-packager` is a collection of tools and scripts to build binaries 
+needed by [Kivy framework](https://kivy.org) apps for different platforms.
 
-Installing them as a single package may save time.
+>[!NOTE]
+> The name has become a misnomer as the project has evolved; it is no longer
+> about Software Development Kits.
 
-The Kivy SDK Packager (kivy-sdk-packager) repository contains
-the definitions of the SDK for each of three different platforms, and the tools 
-to build and distribute them.
+The tools are intended to be run in automated build environments, including
+Continuos Integration (CI) and Continuous Delivery (CD) tools.
 
-This repository contains scripts for Kivy SDK generation on Windows, macOS and
-Linux.
+Each platform targeted by the Kivy framework has its own needs. Hence, the 
+scripts for each platform are quite different in scope. This repository 
+contains scripts Windows, macOS and Linux.
 
-Kivy SDK Packager is managed by the [Kivy Team](https://kivy.org/about.html).
+For most platforms, this repository contains behind-the-scenes scripts. There is
+no need for developers of Kivy apps to be aware of them.
+
+macOS developers may want to use the scripts here for packaging, but it is 
+recommended that they use [Buildozer](https://buildozer.readthedocs.io/)
+instead. It encapsulates the use of `kivy-sdk-packager`.
+
+You can find a detailed README.md document inside every platform folder.
+They explain what the provided files do, what artefacts are produce, and what
+steps are required for each new release.
+
+kivy-sdk-packager is managed by the [Kivy Team](https://kivy.org/about.html).
 
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)
-[![GitHub contributors](https://img.shields.io/github/contributors-anon/kivy/kivy-sdk-packager)](https://github.com/kivy/kivy-sdk-manager/graphs/contributors)
+[![GitHub contributors](https://img.shields.io/github/contributors-anon/kivy/kivy-sdk-packager)](https://github.com/kivy/kivy-sdk-packager/graphs/contributors)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
 ## Linux (Debian)
 
-Kivy SDKs for Linux are distributed as 
+Binaries Linux are distributed as 
 [Personal Package Archives](https://launchpad.net/ubuntu/+ppas) (PPA) files.
-They are built and hosted by [Launchpad](https://launchpad.net/) to the
+They are built by Canonical and hosted on [Launchpad](https://launchpad.net/) to the
 specifications (recipes) provided here.
 
-| Version      | SDK Binary                                                                                           | Source                                                                                          |
+| Version      | Binary                                                                                           | Source                                                                                          |
 |--------------|------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | Stable Build | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       |
 | Daily Build  | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) |
 
-[Kivy SDK for Linux README](linux/debian/README.md)
+More information: [Linux README](linux/debian/README.md)
 
 ## macOS
 
-Kivy SDKs for macOS are built as Disk Image (DMG) files.
+Binaries for macOS are built as Disk Image (.DMG) or App (.APP) files.
 
 These can be built on the developer's machine. 
 
@@ -45,21 +58,23 @@ These can be built on the developer's machine.
 > macOS versions. You need to build Kivy SDKs for macOS on the oldest machine 
 > you wish to support.
 
-[Buildozer](https://buildozer.readthedocs.io) builds and uses Kivy SDKs to 
-package macOS apps.
+[Buildozer](https://buildozer.readthedocs.io) encapsulates the use of 
+kivy-sdk-packager so the Kivy app developer does not need to be concerned with
+it.
 
 [![macOS Tests](https://github.com/kivy/kivy-sdk-packager/actions/workflows/test_macos.yaml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/test_macos.yaml)
 
-[Kivy SDK for macOS README](osx/README.md)
+More information: [macOS README](osx/README.md)
 
 ## Windows
 
-Kivy SDK for Windows are built as wheels that can be installed via 
+Binaries for Windows are built as wheels that can be installed via 
 [pip](https://pypi.org/project/pip/). They are uploaded and hosted on the 
 [Python Package Index](https://pypi.org/) (PyPI).
 
-Four variants are released, based on four different 
-[OpenGL ES](https://en.wikipedia.org/wiki/OpenGL_ES) implementations:
+Four variants are released - they contain support for different  
+[OpenGL ES](https://en.wikipedia.org/wiki/OpenGL_ES) implementations and other
+libraries:
 
 | Version                                                                 | PyPI Name                                                            |
 |-------------------------------------------------------------------------|----------------------------------------------------------------------|
@@ -68,34 +83,33 @@ Four variants are released, based on four different
 | [Gstreamer](https://gstreamer.freedesktop.org/)                         | [kivy-deps.gstreamer](https://pypi.org/project/kivy-deps.gstreamer/) |
 | [SDL2](https://www.libsdl.org/)                                         | [kivy-deps.sdl2](https://pypi.org/project/kivy-deps.sdl2/)           |
 
-
-
 [![Windows Angle wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_angle_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_angle_wheels.yml)
 [![Windows Glew wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_glew_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_glew_wheels.yml)
 [![Windows Gstreamer wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_gstreamer_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_gstreamer_wheels.yml)
 [![Windows SDL2 wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_sdl2_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_sdl2_wheels.yml)
 
-[Kivy SDK for Windows README](win/README.md)
+More information: [Windows README](win/README.md)
 
 ## License
 
-Kivy SDK Packager is [MIT licensed](LICENSE), actively developed by a great
+kivy-sdk-packager is [MIT licensed](LICENSE), actively developed by a great
 community and is supported by many projects managed by the 
 [Kivy Organization](https://www.kivy.org/about.html).
 
 ## Support
 
-Are you having trouble using Kivy SDK Packager or any of its related projects in the Kivy
-ecosystem?
+Are you having trouble using kivy-sdk-packager or any of its related projects in
+the Kivy ecosystem?
 Is there an error you don’t understand? Are you trying to figure out how to use 
 it? We have volunteers who can help!
 
 The best channels to contact us for support are listed in the latest 
-[Contact Us](https://github.com/kivy/kivy-sdk-packager/blob/master/CONTACT.md) document.
+[Contact Us](https://github.com/kivy/kivy-sdk-packager/blob/master/CONTACT.md) 
+document.
 
 ## Contributing
 
-Kivy SDK Packager is part of the [Kivy](https://kivy.org) ecosystem - a large group of
+kivy-sdk-packager is part of the [Kivy](https://kivy.org) ecosystem - a large group of
 products used by many thousands of developers for free, but it
 is built entirely by the contributions of volunteers. We welcome (and rely on) 
 users who want to give back to the community by contributing to the project.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ recommended that they use [Buildozer](https://buildozer.readthedocs.io/)
 instead. It encapsulates the use of `kivy-sdk-packager`.
 
 You can find a detailed README.md document inside every platform folder.
-They explain what the provided files do, what artefacts are produce, and what
+They explain what the provided files do, what artefacts are produced, and what
 steps are required for each new release.
 
 kivy-sdk-packager is managed by the [Kivy Team](https://kivy.org/about.html).
@@ -35,7 +35,7 @@ kivy-sdk-packager is managed by the [Kivy Team](https://kivy.org/about.html).
 
 ## Linux (Debian)
 
-Binaries Linux are distributed as 
+Binaries for Linux are distributed as 
 [Personal Package Archives](https://launchpad.net/ubuntu/+ppas) (PPA) files.
 They are built by Canonical and hosted on [Launchpad](https://launchpad.net/) to the
 specifications (recipes) provided here.
@@ -53,10 +53,6 @@ Binaries for macOS are built as Disk Image (.DMG) or App (.APP) files.
 
 These can be built on the developer's machine. 
 
-> [!NOTE]
-> A Kivy.app build on one macOS version will typically not work on earlier
-> macOS versions. You need to build Kivy SDKs for macOS on the oldest machine 
-> you wish to support.
 
 [Buildozer](https://buildozer.readthedocs.io) encapsulates the use of 
 kivy-sdk-packager so the Kivy app developer does not need to be concerned with

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Kivy SDKs for macOS are built as Disk Image (DMG) files.
 
 These can be built on the developer's machine. 
 
-> [!NOTE]: 
+> [!NOTE]
 > A Kivy.app build on one macOS version will typically not work on earlier
 > macOS versions. You need to build Kivy SDKs for macOS on the oldest machine 
 > you wish to support.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,161 @@
 Kivy SDK Packager
 =================
 
-This repository contains scripts for Kivy SDK generation on Windows, OS X and Linux.
+Kivy Software Development Kit (Kivy SDK) is an installable package of all the 
+basic dependencies needed to run [Kivy framework](https://kivy.org) apps.
+
+Installing them as a single package may save time.
+
+The Kivy SDK Packager (kivy-sdk-packager) repository contains
+the definitions of the SDK for each of three different platforms, and the tools 
+to build and distribute them.
+
+This repository contains scripts for Kivy SDK generation on Windows, macOS and
+Linux.
+
+Kivy SDK Packager is managed by the [Kivy Team](https://kivy.org/about.html).
+
+[![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
+[![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)
+[![GitHub contributors](https://img.shields.io/github/contributors-anon/kivy/kivy-sdk-packager)](https://github.com/kivy/kivy-sdk-manager/graphs/contributors)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+
+## Linux (Debian)
+
+Kivy SDKs for Linux are distributed as 
+[Personal Package Archives](https://launchpad.net/ubuntu/+ppas) (PPA) files.
+They are built and hosted by [Launchpad](https://launchpad.net/) to the
+specifications (recipes) provided here.
+
+| Version      | SDK Binary                                                                                           | Source                                                                                          |
+|--------------|------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| Stable Build | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy/+packages)       |
+| Daily Build  | [Launchpad PPA packages](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) | [Launchpad recipes](https://code.launchpad.net/~kivy-team/+archive/ubuntu/kivy-daily/+packages) |
+
+[Kivy SDK for Linux README](linux/README.md)
+
+## macOS
+
+Kivy SDKs for macOS are built as Disk Image (DMG) files.
+
+These can be built on the developer's machine. 
+
+> [!NOTE]: 
+> A Kivy.app build on one macOS version will typically not work on earlier
+> macOS versions. You need to build Kivy SDKs for macOS on the oldest machine 
+> you wish to support.
+
+[Buildozer](https://buildozer.readthedocs.io) builds and uses Kivy SDKs to 
+package macOS apps.
+
+[![macOS Tests](https://github.com/kivy/kivy-sdk-packager/actions/workflows/test_macos.yaml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/test_macos.yaml)
+
+[Kivy SDK for macOS README](osx/README.md)
+
+## Windows
+
+Kivy SDK for Windows are built as wheels that can be installed via 
+[pip](https://pypi.org/project/pip/). They are uploaded and hosted on the 
+[Python Package Index](https://pypi.org/) (PyPI).
+
+Four variants are released, based on four different 
+[OpenGL ES](https://en.wikipedia.org/wiki/OpenGL_ES) implementations:
+
+| Version                                                                 | PyPI Name                                                            |
+|-------------------------------------------------------------------------|----------------------------------------------------------------------|
+| [Angle](https://chromium.googlesource.com/angle/angle/+/main/README.md) | [kivy-deps.angle](https://pypi.org/project/kivy-deps.angle/)         |
+| [Glew](https://glew.sourceforge.net/)                                   | [kivy-deps.glew](https://pypi.org/project/kivy-deps.glew/)           |
+| [Gstreamer](https://gstreamer.freedesktop.org/)                         | [kivy-deps.gstreamer](https://pypi.org/project/kivy-deps.gstreamer/) |
+| [SDL2](https://www.libsdl.org/)                                         | [kivy-deps.sdl2](https://pypi.org/project/kivy-deps.sdl2/)           |
+
+
+
+[![Windows Angle wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_angle_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_angle_wheels.yml)
+[![Windows Glew wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_glew_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_glew_wheels.yml)
+[![Windows Gstreamer wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_gstreamer_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_gstreamer_wheels.yml)
+[![Windows SDL2 wheels](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_sdl2_wheels.yml/badge.svg)](https://github.com/kivy/kivy-sdk-packager/actions/workflows/windows_sdl2_wheels.yml)
+
+[Kivy SDK for Windows README](win/README.md)
+
+## License
+
+Kivy SDK Packager is [MIT licensed](LICENSE), actively developed by a great
+community and is supported by many projects managed by the 
+[Kivy Organization](https://www.kivy.org/about.html).
+
+## Support
+
+Are you having trouble using Kivy SDK Packager or any of its related projects in the Kivy
+ecosystem?
+Is there an error you don’t understand? Are you trying to figure out how to use 
+it? We have volunteers who can help!
+
+The best channels to contact us for support are listed in the latest 
+[Contact Us](https://github.com/kivy/kivy-sdk-packager/blob/master/CONTACT.md) document.
+
+## Contributing
+
+Kivy SDK Packager is part of the [Kivy](https://kivy.org) ecosystem - a large group of
+products used by many thousands of developers for free, but it
+is built entirely by the contributions of volunteers. We welcome (and rely on) 
+users who want to give back to the community by contributing to the project.
+
+Contributions can come in many forms. See the latest 
+[Contribution Guidelines](https://github.com/kivy/kivy-sdk-packager/blob/master/CONTRIBUTING.md)
+for how you can help us.
+
+## Code of Conduct
+
+In the interest of fostering an open and welcoming community, we as 
+contributors and maintainers need to ensure participation in our project and 
+our sister projects is a harassment-free and positive experience for everyone. 
+It is vital that all interaction is conducted in a manner conveying respect, 
+open-mindedness and gratitude.
+
+Please consult the [latest Code of Conduct](https://github.com/kivy/kivy-sdk-packager/blob/master/CODE_OF_CONDUCT.md).
+
+## Contributors
+
+This project exists thanks to 
+[all the people who contribute](https://github.com/kivy/kivy-sdk-packager/graphs/contributors).
+[[Become a contributor](CONTRIBUTING.md)].
+
+<img src="https://contrib.nn.ci/api?repo=kivy/kivy-sdk-packager&pages=5&no_bot=true&radius=22&cols=18">
+
+## Backers
+
+Thank you to [all of our backers](https://opencollective.com/kivy)! 
+🙏 [[Become a backer](https://opencollective.com/kivy#backer)]
+
+<img src="https://opencollective.com/kivy/backers.svg?width=890&avatarHeight=44&button=false">
+
+## Sponsors
+
+Special thanks to 
+[all of our sponsors, past and present](https://opencollective.com/kivy).
+Support this project by 
+[[becoming a sponsor](https://opencollective.com/kivy#sponsor)].
+
+Here are our top current sponsors. Please click through to see their websites,
+and support them as they support us. 
+
+<!--- See https://github.com/orgs/kivy/discussions/15 for explanation of this code. -->
+<a href="https://opencollective.com/kivy/sponsor/0/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/1/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/2/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/3/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/3/avatar.svg"></a>
+
+<a href="https://opencollective.com/kivy/sponsor/4/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/5/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/6/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/7/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/7/avatar.svg"></a>
+
+<a href="https://opencollective.com/kivy/sponsor/8/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/9/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/10/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/11/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/11/avatar.svg"></a>
+
+<a href="https://opencollective.com/kivy/sponsor/12/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/13/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/14/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/15/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/15/avatar.svg"></a>

--- a/osx/README.md
+++ b/osx/README.md
@@ -11,10 +11,6 @@ The packaged dmg contains a Python virtualenv, Kivy and its binary dependencies 
 provides an existing dmg containing the virtualenv and Kivy pre-installed that can be used
 as a base into which your app can be installed and packaged again as a dmg. Below are the steps:
 
-**Note:** A Kivy.app build on one OS X version will typically
-not work on older OS X versions. For older OS X versions, you need to build Kivy.app
-on the oldest machine you wish to support.
-
 * Get the Kivy sdk repo with e.g.
   ``git clone https://github.com/kivy/kivy-sdk-packager.git`` and ``cd`` into
   ``kivy-sdk-packager/osx``.

--- a/win/common.py
+++ b/win/common.py
@@ -181,7 +181,7 @@ data = [
 setup(
     name='{}',
     version='{}',
-    author='Kivy Crew',
+    author='Kivy Team and other contributors',
     author_email='kivy-dev@googlegroups.com',
     description='Repackaged binary dependency of Kivy.',
     url='http://kivy.org/',


### PR DESCRIPTION
This is part of an effort to make the Kivy sibling projects' documentation structure consistent and up-to-date.

Unrelated items:
* Readme was vestigial. Wrote description from scratch.

CHECKLIST

* CONTRIBUTING.md
   [x] If repo takes user contributions, is present
   [x] In root dir (not .github dir)
   [x] Explains relationship to Kivy, if unclear.
   [x] Refers to kivy/kivy Contribution Guidelines.
   
* LICENSE
   [x] If repo takes user contributions, is present.
   [x] Acknowledges the range of years to 2023.
   [x] Acknowledges Kivy Team and other contributors
   [x] Mentions it is an MIT License.
   
* CODE_OF_CONDUCT.md
   [x] If repo takes user contributions or hosts discussions, is present.
   [x] Refers to kivy/kivy CODE_OF_CONDUCT.md
   
* CONTACT.md
   [x] Refers to kivy/kivy CONTACT.md

* FAQ.md
   [NA] If repo is big enough for RST documentation, is present.
   
* README:
   [x] Is a Markdown file.
   [x] Describes the project.
   [x] Describes its place in the Kivy sibling projects.
   [NA] If Documentation exists, mention it.
   [x] If CONTRIBUTING exists, mentions it.
   [x] If LICENSE exists, mentions it.
   [x] If CODE_OF_CONDUCT exists, mentions it.
   [x] Mentions kivy/kivy CONTACT.md
   [NA] Uses Python syntax colouring for embedded Python code.
   [x] Uses badges to display current status, including:
        [x] Backers
		[x] Sponsors
		[x] GitHub contributors
		[x] Contributor Covenant
		[NA] PyPI Version
		[NA] PyPI Python Version
		[x] Build/Test status

   [x] Displays all contributors to the repo.		
   [x] Displays backers
   [x] Displays top sponsors.

* RST documentation, if present
   [NA] Describes the project.
   [NA] Describes its place in the Kivy sibling projects.
   [NA] Mentions (Kivy/Kivy) Contact Us link.
   [NA] Mentions LICENSE.
   [NA] Mentions CONTRIBUTING
   [NA] Mentions FAQ
   [NA] conf.py mentioned Kivy Team and other contributors
		- copyright, latex_documents, man_pages, texinfo documents
   
   
* WORKFLOWS
   [NA] NO_RESPONSE.yml is present if the repo has awaiting_reply tag.
   [NA] NO_RESPONSE uses latest script versions.
   [NA] SUPPORT.yml is present if the repo has a `support` tag.
   [NA] SUPPORT.yml refers to repo's CONTACT.md

* setup.py/cfg, if present and on PyPI
   Note: Template used for Kivy SDK for Windows 
   [too hard] Supplies description to PyPI
   [too hard] Supplies Python versions to PyPI
   [x] Supplies Documentation, if any, to PyPI
