### PR TITLE
Add Python `3.12` to matrix for `glew` and update Github Actions for related jobs

### DIFF
--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -26,13 +26,13 @@ jobs:
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Cache deps
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: kivy_build_cache
           key: cache-packages-glew-${{ matrix.arch }}-${{ hashFiles('win/glew.py') }}
@@ -51,19 +51,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
     - name: Cache deps
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: kivy_build_cache
         key: cache-packages-glew-${{ matrix.arch }}-${{ hashFiles('win/glew.py') }}


### PR DESCRIPTION
Adds Python `3.12` to matrix for `glew` and updates Github Actions for related jobs.

`glew` version has not been bumped as there are no new releases available (A wheel will be uploaded only for `3.12`)