### PR TITLE
[publish angle win] Update `angle` version and add Python `3.12` to matrix for `angle` and update Github Actions for related jobs

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Get dependecies
         run: |
           . .\ci\windows_ci.ps1
@@ -33,7 +33,7 @@ jobs:
         run: |
           . .\ci\windows_ci.ps1
           Build-angle
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: angle_dlls
           path: angle_dlls
@@ -45,14 +45,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64', 'x86']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
@@ -60,7 +60,7 @@ jobs:
       run: |
         . .\ci\windows_ci.ps1
         Prepre-env
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: angle_dlls
     - name: Build package
@@ -68,7 +68,7 @@ jobs:
         . .\ci\windows_ci.ps1
         Create-Packages
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: angle_wheels
         path: dist

--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -63,6 +63,7 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: angle_dlls
+        path: angle_dlls
     - name: Build package
       run: |
         . .\ci\windows_ci.ps1

--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   prepare_angle:
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     steps:

--- a/ci/windows_ci.ps1
+++ b/ci/windows_ci.ps1
@@ -67,7 +67,7 @@ function Test-kivy() {
 function Get-angle-deps() {
     Invoke-WebRequest -Uri "https://storage.googleapis.com/chrome-infra/depot_tools.zip" -OutFile depot_tools.zip
     7z x depot_tools.zip -odepot_tools
-    git clone -b "chromium/4758" --single-branch https://github.com/google/angle.git angle_src
+    git clone -b "chromium/6045" --single-branch https://github.com/google/angle.git angle_src
 }
 
 function Build-angle() {

--- a/win/angle.py
+++ b/win/angle.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from .common import *
 
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 
 
 def get_angle(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
Adds Python `3.12` to matrix for `angle` and updates Github Actions for related jobs.

- Bump `angle` from `chromium/4758` to `chromium/6045` (See https://chromiumdash.appspot.com/branches and https://github.com/google/angle/blob/main/doc/ChoosingANGLEBranch.md for how to choosing an ANGLE branch to track)
- Change the version for `kivy_deps.angle` from `0.3.3` to `0.4.0`

Keeping the previous version was not possible as:
- `windows-latest` can't build `chromium/4758`, does not provide the proper Visual Studio setup.
- [A change in depot_tools](https://groups.google.com/a/chromium.org/g/chromium-dev/c/xFYvFYGQUGI) broke the build of `chromium/4758` even on `windows-2019`

✅ Tested locally on Windows 11 x86_64
⚠️ Add `[publish angle win]` before merge.