### PR TITLE
Sunset `apple-silicon-m1` self-hosted runner, as now is supported by Github Hosted runners via `macos-latest` tag. Use `macos-13` for runs on Intel macs

### DIFF
--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: [macos-latest, macos-13]
     name: macOS build dmg ( ${{ matrix.runs_on }} )
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +67,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: [macos-latest, macos-13]
     name: macOS test dmg ( ${{ matrix.runs_on }} )
     steps:
       - uses: actions/checkout@v4
@@ -74,12 +78,12 @@ jobs:
         with:
           name: KivySDKPackager
           path: osx_artifacts
-      - name: Mount build from macos-latest runner on apple-silicon-m1 runner
-        if: ${{ matrix.runs_on  == 'apple-silicon-m1' }}
+      - name: Mount build from macos-latest runner on macos-13 runner
+        if: ${{ matrix.runs_on  == 'macos-13' }}
         run: hdiutil attach osx_artifacts/macos-latest-Kivy.dmg -mountroot .
-      - name: Mount build from apple-silicon-m1n runner on macos-latest runner
-        if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
-        run: hdiutil attach osx_artifacts/apple-silicon-m1-Kivy.dmg -mountroot .
+      - name: Mount build from macos-13 runner on macos-latest runner
+        if: ${{ matrix.runs_on  != 'macos-latest' }}
+        run: hdiutil attach osx_artifacts/macos-13-Kivy.dmg -mountroot .
       - name: Copy Kivy.app to Applications
         run: cp -R Kivy/Kivy.app /Applications/Kivy.app
       - name: Activate Kivy.app venv and test kivy


### PR DESCRIPTION
The time has come, as being announced in https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image , `macos-latest` on `kivy/kivy` repo is already targeting `macos-14`, which is an Apple Silicon runner.

Therefore, our self-hosted `apple-silicon-m1` runner, after ~1.5 years of service will start the sunset phase.

However, now comes an additional issue: "How can we make sure to properly test things for Intel Macs?".

As ATM https://github.com/orgs/community/discussions/116568, is still unanswered, targeting `macos-13` for testing on an Intel runner looks like the best (free of charge) choice.
I guess the long-time alternative is `macos-latest-large`, which is a `macos-14` image that runs on Intel Macs, but is quite pricey for us.

What will be the future of `apple-silicon-m1` runner hardware?
- iOS Simulators?
- Android Emulators?

Similar PRs: https://github.com/kivy/kivy/pull/8713