### PR TITLE
Add SDL3 wheels for `kivy_deps.sdl3` and `kivy_deps.sdl3_dev` [publish sdl3 win]

### DIFF
--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -20,7 +20,7 @@ env:
   PYTHONPATH: .
 
 jobs:
-  prepare_build:
+  prepare_sdl3_build:
     runs-on: windows-latest
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
 
   windows_wheels:
     runs-on: windows-latest
-    needs: prepare_build
+    needs: prepare_sdl3_build
     strategy:
       fail-fast: false
       matrix:
@@ -54,14 +54,14 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
-    - uses: actions/download-artifact@v4
-      with:
-        name: sdl3_build_${{ matrix.arch }}
-        path: kivy_build
     - name: Prepare Environment
       run: |
         . .\ci\windows_ci.ps1
         Prepre-env
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdl3_build_${{ matrix.arch }}
+        path: kivy_build
     - name: Build package
       run: |
         . .\ci\windows_ci.ps1

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -71,4 +71,27 @@ jobs:
       with:
         name: sdl3_wheel_${{ matrix.arch }}_${{ matrix.python }}
         path: dist
+    - name: Install MSYS2
+      if: contains(github.event.head_commit.message, '[publish sdl3 win]')
+      run: choco install msys2
+    - name: Upload wheels to server
+      if: contains(github.event.head_commit.message, '[publish sdl3 win]')
+      env:
+        UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
+        MSYSTEM: MINGW64
+        CHERE_INVOKING: 1
+      run: |
+        . .\ci\windows_ci.ps1
+        Upload-windows-wheels-to-server -ip "$env:SERVER_IP"
+    - name: Publish to PyPI
+      if: contains(github.event.head_commit.message, '[publish sdl3 win]')
+      env:
+        TWINE_USERNAME: "__token__"
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: |
+        twine upload --non-interactive dist/*
+    - name: Test package
+      run: |
+        . .\ci\windows_ci.ps1
+        Test-kivy
 

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   SERVER_IP: '159.203.106.198'
-  KIVY_BUILD_DIR: kivy-dependencies\dist
+  KIVY_BUILD_DIR: kivy_build
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: sdl3
   PYTHONPATH: .
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: sdl3_build_${{ matrix.arch }}
-          path: kivy-dependencies
+          path: kivy-dependencies/dist
 
   windows_wheels:
     runs-on: windows-latest
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: sdl3_build_${{ matrix.arch }}
-        path: kivy-dependencies
+        path: kivy_build
     - name: Prepare Environment
       run: |
         . .\ci\windows_ci.ps1

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -1,0 +1,74 @@
+name: SDL3 wheels
+
+on:
+  push:
+    branches:
+      - master
+      - windows_ci
+    paths:
+      - 'win/common.py'
+      - 'win/sdl3.py'
+      - 'win/build_sdl3.ps1'
+      - 'ci/windows_ci.ps1'
+      - '.github/workflows/windows_sdl3_wheels.yml'
+
+env:
+  SERVER_IP: '159.203.106.198'
+  KIVY_BUILD_DIR: kivy-dependencies\dist
+  KIVY_BUILD_CACHE: kivy_build_cache
+  PACKAGE_TARGET: sdl3
+  PYTHONPATH: .
+
+jobs:
+  prepare_build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: ['x64']
+    env:
+      PACKAGE_ARCH: ${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build SDL3 for arch ${{ matrix.arch }}
+        run: |
+          ./win/build_sdl3.ps1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdl3_build_${{ matrix.arch }}
+          path: kivy-dependencies
+
+  windows_wheels:
+    runs-on: windows-latest
+    needs: prepare_build
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12' ]
+        arch: ['x64']
+    env:
+      PACKAGE_ARCH: ${{ matrix.arch }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        architecture: ${{ matrix.arch }}
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdl3_build_${{ matrix.arch }}
+        path: kivy-dependencies
+    - name: Prepare Environment
+      run: |
+        . .\ci\windows_ci.ps1
+        Prepre-env
+    - name: Build package
+      run: |
+        . .\ci\windows_ci.ps1
+        Create-Packages
+    - name: Upload wheels as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdl3_wheel_${{ matrix.arch }}_${{ matrix.python }}
+        path: dist
+

--- a/win/build_sdl3.ps1
+++ b/win/build_sdl3.ps1
@@ -1,0 +1,144 @@
+# Extract the build architecture from the arguments
+param(
+    [string]$build_arch = "x64"
+)
+
+# Check if KIVY_DEPS_BUILD is set
+if ($env:KIVY_DEPS_BUILD) {
+    Write-Host "KIVY_DEPS_BUILD is set. Powershell script should be run in a clean environment."
+    exit 1
+}
+# Set KIVY_DEPS_BUILD to 1
+$env:KIVY_DEPS_BUILD = 1
+
+Write-Host "Building SDL3 dependencies for $build_arch architecture."
+
+# Cleaning the kivy-dependencies/download, kivy-dependencies/build and kivy-dependencies/dist folders
+Write-Host "Cleaning the kivy-dependencies folder..."
+Remove-Item -Path "kivy-dependencies" -Force -Recurse -ErrorAction SilentlyContinue
+
+# Create the kivy-dependencies folder
+New-Item -ItemType Directory -Path kivy-dependencies
+
+# Create the kivy-dependencies/Powershell folder
+New-Item -ItemType Directory -Path kivy-dependencies/WindowsPowerShell/Modules
+
+pushd kivy-dependencies
+Write-Host "Downloading the Visual Studio Setup PowerShell module ..."
+Invoke-WebRequest -Uri "https://github.com/microsoft/vssetup.powershell/releases/download/2.2.12-65a71775b3/VSSetup.zip" -OutFile "VSSetup.zip"
+Expand-Archive VSSetup.zip "WindowsPowerShell\Modules\VSSetup"
+Write-Host "Visual Studio Setup PowerShell module downloaded."
+popd
+
+Write-Host "Adding the Visual Studio Setup PowerShell module to the PSModulePath ..."
+$env:PSModulePath = $env:PSModulePath + ";$(pwd)\kivy-dependencies\WindowsPowerShell\Modules"
+
+# Get the Visual Studio installation path
+$vs_install_path = Get-VSSetupInstance | Where-Object { $_.InstallationPath -ne $null } | Select-Object -ExpandProperty InstallationPath
+Write-Host "Visual Studio installation path: $vs_install_path"
+
+# Set the environment variables via vcvarsall.bat
+$vcvars_path = "$vs_install_path/VC/Auxiliary/Build/vcvarsall.bat"
+Write-Host "vcvarsall path: $vcvars_path"
+
+# Call the .bat file from the PowerShell script
+cmd.exe /c " `"$vcvars_path`" $build_arch && set" | ForEach-Object {
+    if ($_ -match "=") {
+        $v = $_.split("=", 2);
+        Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])";
+        Write-host "Setting $($v[0]) to $($v[1])"
+    }
+};
+
+write-host "`nVisual Studio Command Prompt variables set." -ForegroundColor Yellow
+
+
+# Create the kivy-dependencies/download folder
+New-Item -ItemType Directory -Path kivy-dependencies/download
+
+# Create the build folder for the dependencies
+New-Item -ItemType Directory -Path kivy-dependencies/build  
+
+# Create the dist folder for the dependencies
+New-Item -ItemType Directory -Path kivy-dependencies/dist
+
+# windows SDL3
+$WINDOWS__SDL3__VERSION = "3.1.2"
+$WINDOWS__SDL3__URL="https://github.com/libsdl-org/SDL/archive/refs/heads/main.tar.gz"
+$WINDOWS__SDL3__FOLDER="SDL-main"
+
+# windows SDL3_image
+$WINDOWS__SDL3_IMAGE__URL="https://github.com/libsdl-org/SDL_image/archive/refs/heads/main.tar.gz"
+$WINDOWS__SDL3_IMAGE__FOLDER="SDL_image-main"
+
+# windows SDL3_mixer
+$WINDOWS__SDL3_MIXER__URL="https://github.com/libsdl-org/SDL_mixer/archive/refs/heads/main.tar.gz"
+$WINDOWS__SDL3_MIXER__FOLDER="SDL_mixer-main"
+
+# windows SDL3_ttf
+$WINDOWS__SDL3_TTF__URL="https://github.com/libsdl-org/SDL_ttf/archive/refs/heads/main.tar.gz"
+$WINDOWS__SDL3_TTF__FOLDER="SDL_ttf-main"
+
+# Download the dependencies
+Write-Host "Downloading the dependencies..."
+Write-Host "-- SDL3, url: $WINDOWS__SDL3__URL"
+Invoke-WebRequest -Uri $WINDOWS__SDL3__URL -OutFile "kivy-dependencies/download/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
+Invoke-WebRequest -Uri $WINDOWS__SDL3_IMAGE__URL -OutFile "kivy-dependencies/download/SDL_image-main.tar.gz"
+Invoke-WebRequest -Uri $WINDOWS__SDL3_MIXER__URL -OutFile "kivy-dependencies/download/SDL_mixer-main.tar.gz"
+Invoke-WebRequest -Uri $WINDOWS__SDL3_TTF__URL -OutFile "kivy-dependencies/download/SDL_ttf-main.tar.gz"
+
+# Save dist folder full path
+$dist_folder = (Get-Item -Path ".\kivy-dependencies\dist").FullName
+
+pushd kivy-dependencies/build
+
+Write-Host "Extracting the dependencies..."
+# Extract the dependencies
+tar -xf "../download/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
+tar -xf "../download/SDL_image-main.tar.gz"
+tar -xf "../download/SDL_mixer-main.tar.gz"
+tar -xf "../download/SDL_ttf-main.tar.gz"
+
+# Move into the SDL3 folder
+Write-Host "-- Build SDL3"
+cd "SDL-main"
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX="$dist_folder" -DCMAKE_BUILD_TYPE=Release -GNinja
+cmake --build build/ --config Release --verbose --parallel
+cmake --install build/ --config Release
+
+cd ..
+
+# Move into the SDL_mixer folder
+Write-Host "-- Build SDL_mixer"
+cd "SDL_mixer-main"
+./external/Get-GitModules.ps1
+cmake -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release -DSDL3MIXER_VENDORED=ON  -DSDL3_DIR="$dist_folder/cmake"  -DCMAKE_INSTALL_PREFIX="$dist_folder" -GNinja
+cmake --build build/ --config Release --parallel --verbose
+cmake --install build/ --config Release
+cd ..
+
+# Move into the SDL_image folder
+Write-Host "-- Build SDL_image"
+cd "SDL_image-main"
+./external/Get-GitModules.ps1
+cmake -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DSDL3IMAGE_TIF_VENDORED=ON -DSDL3IMAGE_WEBP_VENDORED=ON -DSDL3IMAGE_JPG_VENDORED=ON -DSDL3IMAGE_PNG_VENDORED=ON -DSDL3IMAGE_TIF_SHARED=OFF -DSDL3IMAGE_WEBP_SHARED=OFF  -DSDL3IMAGE_VENDORED=OFF -DSDL3_DIR="$dist_folder/cmake"  -DCMAKE_INSTALL_PREFIX="$dist_folder" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -GNinja
+cmake --build build/ --config Release --parallel --verbose
+cmake --install build/ --config Release
+cd ..
+
+# Move into the SDL_ttf folder
+Write-Host "-- Build SDL_ttf"
+cd "SDL_ttf-main"
+./external/Get-GitModules.ps1
+cmake -B build-cmake -DBUILD_SHARED_LIBS=ON -DSDL3TTF_HARFBUZZ=ON -DFT_DISABLE_PNG=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release -DSDL3TTF_VENDORED=ON -DSDL3_DIR="$dist_folder/cmake"  -DCMAKE_INSTALL_PREFIX="$dist_folder" -GNinja
+cmake --build build-cmake --config Release --verbose
+cmake --install build-cmake/ --config Release --verbose
+cd ..
+
+popd
+
+# Set KIVY_DEPS_ROOT to the dist folder
+Write-Host "Setting KIVY_DEPS_ROOT to $dist_folder"
+$env:KIVY_DEPS_ROOT = $dist_folder
+
+Write-Host "Dependencies built successfully."

--- a/win/sdl3.py
+++ b/win/sdl3.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, print_function
+from .common import *
+
+__version__ = "0.0.1"
+
+
+def get_sdl3(cache, build_path, arch, package, output, download_only=False):
+    data = []
+    base_dll_dir = join(build_path, "bin")
+
+    sources = {
+            'bin': join(build_path, 'bin'),
+            'lib': join(build_path, 'lib'),
+            'include': join(build_path, 'include')
+            }
+
+    for d, src in sources.items():
+        # bin goes to python/share/kivy_package
+        for dirpath, dirnames, filenames in os.walk(src):
+            root = dirpath
+
+            if d == 'bin':
+                base = join('share', package, 'bin')
+            elif d == 'lib':
+                base = 'libs'
+            elif d == 'include':
+                base = 'include'
+            else:
+                assert False
+
+            dirpath = dirpath.replace(src, '')
+            if dirpath and dirpath[0] == sep:
+                dirpath = dirpath[1:]
+
+            for filename in filenames:
+                is_dev = d != 'bin'
+                if d == 'lib':
+                    if filename.endswith('lib'):
+                        base = 'libs'
+                    else:
+                        base = join('share', package, 'bin')
+                        is_dev = False
+                data.append((
+                    join(root, filename), join(d, dirpath, filename),
+                    join(base, dirpath), is_dev))
+
+    make_package(
+        join(build_path, "project"), package, data, __version__, output, "MIT"
+    )
+
+
+if __name__ == "__main__":
+    parse_args(get_sdl3)


### PR DESCRIPTION
This PR introduces the new `sdl3` and `sdl3_dev` packages for Kivy 3.0.0.

ATM build is performed on `sdl`, `sdl_mixer`, `sdl_image`, `sdl_ttf` main branches, as SDL3 (and sub libs) is still under development.

For this reason, similarly to `angle`,  we will be required to bump the version if something changed on the main branch.
However, I expect SDL3 to be released before Kivy 3.0.0, so things will be more stable in future.

Differently from`kivy_deps.sdl2`, the `kivy_deps.sdl3` packages are built from source, so we can customize our builds, and apply patches faster.

Additionally, it will be quite straightforward to support more architectures in the future.