### PR TITLE
Add missing `popd` in Kivy.app script

### DIFF
--- a/osx/data/script
+++ b/osx/data/script
@@ -13,6 +13,7 @@ ABS_SCRIPT_PATH=$(cd "${SCRIPT_PATH}" && pwd)
 pushd "${SCRIPT_PATH}/venv/bin"
 # must be in current directory
 source activate
+popd
 
 # setup the environment to not mess with the system
 export DYLD_FALLBACK_LIBRARY_PATH="${SCRIPT_PATH}/../lib:$DYLD_FALLBACK_LIBRARY_PATH"


### PR DESCRIPTION
Without this change I was getting the following error:

```
▶ kivy main.py
/Applications/Kivy.app/Contents/Resources/venv/bin ~/Code/Python/kivy_test
python: can't open file '/Applications/Kivy.app/Contents/Resources/venv/bin/main.py': [Errno 2] No such file or directory
```