### PR TITLE
Bump SDL3 recipe version to produce new release (`0.0.2`)

### DIFF
--- a/win/sdl3.py
+++ b/win/sdl3.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from .common import *
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 
 def get_sdl3(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
Builds SDL3 on top of the latest `main` branch commits.

A lot of things changed from the first release (`0.0.1`) which is now incompatible with https://github.com/kivy/kivy/pull/8666