### PR TITLE
Use `actions/upload-artifact@v3` instead of `actions/upload-artifact@master`

### DIFF
--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -76,7 +76,7 @@ jobs:
         . .\ci\windows_ci.ps1
         Create-Packages
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: glew_wheels
         path: dist


### PR DESCRIPTION
As said [here](https://github.com/kivy/kivy-sdk-packager/pull/108#issuecomment-2380578998), `v4` artifacts are not mutable and our pipeline takes advantage of mutable artifacts.

A migration to support `v4` version (as `v3` will be deprecated, soon or later) will be applied in future.
For now, better sticking with `v3` version.