### PR TITLE
Remove Windows 32-bit support for `kivy.deps` artifacts

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' , '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}
     steps:


### PR DESCRIPTION
To reflect changes made in both `master` and `devel-2.3.x` `kivy/kivy` branches, removes Windows 32-bit support for `kivy.deps` artifacts.

The `arch` logic is not been removed yet as could be used in future to support `arm64` artifacts.