### PR TITLE
Remove Python 3.7 support for Windows `kivy.deps` artifacts

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' , '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
Python 3.7 version reached its EOL a long time ago, and support has been removed from both `master` and `devel-2.3.x` `kivy/kivy` branches.
