### PR TITLE
Bump gstreamer to `1.18.6`, as `1.18.5` is not downloadable anymore

### DIFF
--- a/win/gstreamer.py
+++ b/win/gstreamer.py
@@ -6,9 +6,9 @@ from os import walk, listdir, remove
 from .common import *
 import glob  # also imported in common so it must be after
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
-gst_ver = '1.18.5'
+gst_ver = '1.18.6'
 
 glob_escape = glob.escape
 


### PR DESCRIPTION
Gstreamer `1.18.5` has been removed from gstreamer releases mirror, and therefore we're unable to process new builds.

This PR bumps `gstreamer` to bugfix release `1.18.6`