### PR TITLE
Setup Python before processing ANGLE build

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -25,6 +25,9 @@ jobs:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Get dependecies
         run: |
           . .\ci\windows_ci.ps1

--- a/ci/windows_ci.ps1
+++ b/ci/windows_ci.ps1
@@ -72,7 +72,6 @@ function Get-angle-deps() {
 
 function Build-angle() {
     $env:PATH="$(pwd)\depot_tools;$env:PATH"
-    $env:PATH="$(python -c "import os; print(';'.join([p for p in os.environ['PATH'].split(';') if 'Python' not in p and 'python' not in p and 'Chocolatey' not in p]))")"
     cd angle_src
 
     gclient


### PR DESCRIPTION
Fixes build not completing due to Python unavailability.

Uses `actions/setup-python` and removes hacky fix that prevents Python to be available in PATH.