### PR TITLE
Add Python `3.13-dev` to build matrix for Windows deps

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12' ]
+        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
Failures for `3.13-dev` tests are expected as other deps are not yet available.
Will release `gstreamer` now (as version has already been bumped in #120) and other dependencies during the day.