### PR TITLE
Set linux/debian `daily` to version `2.3.1-dev` to reflect recipe in launchpad

### DIFF
--- a/linux/debian/daily/changelog
+++ b/linux/debian/daily/changelog
@@ -1,3 +1,9 @@
+kivy (2.3.1-dev) UNRELEASED; urgency=medium
+
+  * update to new release
+
+ -- Mirko Galimberti <me@mirkogalimberti.com>  Sat, 16 Nov 2024 16:19:00 +0100
+
 kivy (3.0.0-dev) UNRELEASED; urgency=medium
 
   * update to new release


### PR DESCRIPTION
Set `daily` changelog to version `2.3.1`, so it reflects the version built on launchpad