### PR TITLE
Apply `use-relaxed-build-time-reqs-versions.patch` while building daily ppa

### DIFF
--- a/linux/debian/daily/rules
+++ b/linux/debian/daily/rules
@@ -31,6 +31,7 @@ override_dh_installdocs:
 
 override_dh_auto_install:
 	echo "PYTHONPATH is $$PYTHONPATH"
+	patch pyproject.toml < use-relaxed-build-time-reqs-versions.patch
 	for PYX in $(shell py3versions -r); do \
 	    rm -rf pypackages || true; \
 	    $(MAKE) clean; \


### PR DESCRIPTION
PPA builds are performed in a isolated machine with no access to pypi servers, and should use `python3-*` deb packages as a replacement for pip-installable packages.

The required versions for build-time requirements cannot be used in this case. This should not be an issue ATM.

This PR applies a patch to `kivy/kivy` code, so a relaxed version of `setuptools` and other build-time-only tools can be used.