### PR TITLE
Remove support for Python 3.8 on Windows wheels as it reached EOL

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
+        python: [ '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
+        python: [ '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
+        python: [ '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
+        python: [ '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
+        python: [ '3.9', '3.10', '3.11' , '3.12', '3.13-dev' ]
         arch: ['x64']
     env:
       PACKAGE_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
- Python `3.8` has been removed as reached EOL on 2024-10-07
- Minimum supported version in Kivy is now Python `3.9` (https://github.com/kivy/kivy/pull/8935)