### PR TITLE
Bump SDL3 and SDL3_image to release versions + rebuild SDL3_ttf and SDL3_mixer from main branches

### DIFF
--- a/win/build_sdl3.ps1
+++ b/win/build_sdl3.ps1
@@ -63,13 +63,13 @@ New-Item -ItemType Directory -Path kivy-dependencies/build
 New-Item -ItemType Directory -Path kivy-dependencies/dist
 
 # windows SDL3
-$WINDOWS__SDL3__VERSION = "3.1.10"
-$WINDOWS__SDL3__URL="https://github.com/libsdl-org/SDL/releases/download/prerelease-$WINDOWS__SDL3__VERSION/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
+$WINDOWS__SDL3__VERSION = "3.2.2"
+$WINDOWS__SDL3__URL="https://github.com/libsdl-org/SDL/releases/download/release-$WINDOWS__SDL3__VERSION/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
 $WINDOWS__SDL3__FOLDER="SDL3-$WINDOWS__SDL3__VERSION"
 
 # windows SDL3_image
-$WINDOWS__SDL3_IMAGE__VERSION="3.1.0"
-$WINDOWS__SDL3_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/preview-$WINDOWS__SDL3_IMAGE__VERSION/SDL3_image-$WINDOWS__SDL3_IMAGE__VERSION.tar.gz"
+$WINDOWS__SDL3_IMAGE__VERSION="3.2.0"
+$WINDOWS__SDL3_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/release-$WINDOWS__SDL3_IMAGE__VERSION/SDL3_image-$WINDOWS__SDL3_IMAGE__VERSION.tar.gz"
 $WINDOWS__SDL3_IMAGE__FOLDER="SDL3_image-$WINDOWS__SDL3_IMAGE__VERSION"
 
 # windows SDL3_mixer

--- a/win/sdl3.py
+++ b/win/sdl3.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from .common import *
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 def get_sdl3(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
- Bump SDL3 to `3.2.2`
- Bump SDL3_image to `3.2.0`
- Re-build SDL3_ttf and SDL3_mixer from `main` branches