### PR TITLE
Update script

### DIFF
--- a/osx/data/script
+++ b/osx/data/script
@@ -10,9 +10,7 @@ SCRIPT_PATH="$(dirname ${SCRIPT_PATH})"
 ABS_SCRIPT_PATH=$(cd "${SCRIPT_PATH}" && pwd)
 
 # activate the virtualenv
-pushd "${SCRIPT_PATH}/venv/bin"
-# must be in current directory
-source activate
+source "${SCRIPT_PATH}/venv/bin/activate"
 
 # setup the environment to not mess with the system
 export DYLD_FALLBACK_LIBRARY_PATH="${SCRIPT_PATH}/../lib:$DYLD_FALLBACK_LIBRARY_PATH"


### PR DESCRIPTION
in my environment, I can active the venv python use the absolute path, if use the default method, I will get a error, it caused by use my local pc python. so I recommend using an absolute path to activate the environment.