### PR TITLE
Ensure the proper `KIVY_GL_BACKEND` is used while testing the artifacts

### DIFF
--- a/.github/workflows/windows_angle_wheels.yml
+++ b/.github/workflows/windows_angle_wheels.yml
@@ -16,6 +16,7 @@ env:
   KIVY_BUILD_DIR: angle_dlls
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: angle
+  KIVY_GL_BACKEND: angle_sdl3
   PYTHONPATH: .
 
 jobs:

--- a/.github/workflows/windows_glew_wheels.yml
+++ b/.github/workflows/windows_glew_wheels.yml
@@ -15,6 +15,7 @@ env:
   KIVY_BUILD_DIR: kivy_build
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: glew
+  KIVY_GL_BACKEND: angle_sdl3
   PYTHONPATH: .
 
 jobs:

--- a/.github/workflows/windows_gstreamer_wheels.yml
+++ b/.github/workflows/windows_gstreamer_wheels.yml
@@ -15,6 +15,7 @@ env:
   KIVY_BUILD_DIR: kivy_build
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: gstreamer
+  KIVY_GL_BACKEND: angle_sdl3
   PYTHONPATH: .
 
 

--- a/.github/workflows/windows_sdl2_wheels.yml
+++ b/.github/workflows/windows_sdl2_wheels.yml
@@ -16,6 +16,7 @@ env:
   KIVY_BUILD_DIR: kivy_build
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: sdl2
+  KIVY_GL_BACKEND: angle_sdl2
   PYTHONPATH: .
 
 jobs:

--- a/.github/workflows/windows_sdl3_wheels.yml
+++ b/.github/workflows/windows_sdl3_wheels.yml
@@ -17,6 +17,7 @@ env:
   KIVY_BUILD_DIR: kivy_build
   KIVY_BUILD_CACHE: kivy_build_cache
   PACKAGE_TARGET: sdl3
+  KIVY_GL_BACKEND: angle_sdl3
   PYTHONPATH: .
 
 jobs:

--- a/ci/windows_ci.ps1
+++ b/ci/windows_ci.ps1
@@ -45,7 +45,6 @@ function Upload-windows-wheels-to-server($ip) {
 
 function Test-kivy() {
     $env:GST_REGISTRY="~/registry.bin"
-    $env:KIVY_GL_BACKEND="angle_sdl2"
 
     python -m pip config set install.find-links "$(pwd)\dist"
 


### PR DESCRIPTION
As now kivy moved to `sdl3`, we must ensure the proper `KIVY_GL_BACKEND` is used while testing the artifacts.

`angle_sdl2` has been removed, but has been kept as a reference in `windows_sdl2_wheels` in case we need to produce new `sdl2` wheels for maintenance  versions of Kivy. In that case we will need to perform some changes to the test script to ensure the proper version of Kivy is used.