### PR TITLE
Bump SDL3 version to the latest stable release (`3.2.22`) [publish sdl3 win]

### DIFF
--- a/win/build_sdl3.ps1
+++ b/win/build_sdl3.ps1
@@ -63,7 +63,7 @@ New-Item -ItemType Directory -Path kivy-dependencies/build
 New-Item -ItemType Directory -Path kivy-dependencies/dist
 
 # windows SDL3
-$WINDOWS__SDL3__VERSION = "3.2.14"
+$WINDOWS__SDL3__VERSION = "3.2.18"
 $WINDOWS__SDL3__URL="https://github.com/libsdl-org/SDL/releases/download/release-$WINDOWS__SDL3__VERSION/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
 $WINDOWS__SDL3__FOLDER="SDL3-$WINDOWS__SDL3__VERSION"
 

--- a/win/build_sdl3.ps1
+++ b/win/build_sdl3.ps1
@@ -63,7 +63,7 @@ New-Item -ItemType Directory -Path kivy-dependencies/build
 New-Item -ItemType Directory -Path kivy-dependencies/dist
 
 # windows SDL3
-$WINDOWS__SDL3__VERSION = "3.2.18"
+$WINDOWS__SDL3__VERSION = "3.2.22"
 $WINDOWS__SDL3__URL="https://github.com/libsdl-org/SDL/releases/download/release-$WINDOWS__SDL3__VERSION/SDL3-$WINDOWS__SDL3__VERSION.tar.gz"
 $WINDOWS__SDL3__FOLDER="SDL3-$WINDOWS__SDL3__VERSION"
 

--- a/win/sdl3.py
+++ b/win/sdl3.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 from .common import *
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 
 def get_sdl3(cache, build_path, arch, package, output, download_only=False):


### PR DESCRIPTION
[windows_ci run](https://github.com/DexerBR/kivy-sdk-packager/actions/runs/16663894393)